### PR TITLE
Tides controller and tests 

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
@@ -1,9 +1,44 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import edu.ucsb.cs156.spring.backenddemo.services.LocationQueryService;
+import edu.ucsb.cs156.spring.backenddemo.services.TidesQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+@Tag(name = "Tides info from api.tidesandcurrents.noaa.gov") // https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date=20230710&end_date=20230712&station=9411340&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json	
+@Slf4j
 @RestController
+@RequestMapping("/api/tides/")
 public class TidesController {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    TidesQueryService tidesQueryService;
+
+    @Operation(summary = "Get list of Tides that match a given beginDate, endDate, and station name",
+               description =  "Uses API documented here: https://api.tidesandcurrents.noaa.gov/api/prod/\t")
+    @GetMapping("/get")
+    public ResponseEntity<String> getTides(
+            @Parameter(name="beginDate", description="Begin date", example = "20231231") @RequestParam String beginDate,
+            @Parameter(name="endDate", description="End date", example = "20240120") @RequestParam String endDate,
+            @Parameter(name="station", description="Station ID", example = "9411340") @RequestParam String station
+    ) throws JsonProcessingException {
+        log.info("getTides: beginDate={}, endDate={}, station={}", beginDate, endDate, station);
+        String result = tidesQueryService.getJSON(beginDate, endDate, station);
+        return ResponseEntity.ok().body(result);
+    }
 
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
@@ -1,0 +1,46 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.spring.backenddemo.services.TidesQueryService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = TidesController.class)
+public class TidesControllerTests {
+    private ObjectMapper mapper = new ObjectMapper();
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    TidesQueryService mockTidesQueryService;
+
+
+    @Test
+    public void test_getTides() throws Exception {
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+        String beginDate = "20231231";
+        String endDate = "20240120";
+        String station = "9411340";
+        when(mockTidesQueryService.getJSON(eq(beginDate), eq(endDate), eq(station))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/tides/get?beginDate=%s&endDate=%s&station=%s", beginDate, endDate, station);
+        MvcResult response = mockMvc
+                .perform(get(url).contentType("application/json"))
+                .andExpect(status().isOk())
+                .andReturn();
+        
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/tides/get` that can be used to get information
about the information of using beginDate, endDate, and station.

Closes #13 