### PR TITLE
Add University Service and Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
@@ -19,12 +19,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name="University info")
-// @Operation(summary = "Get info about universities based on their name", description = "JSON return format documented here: http://universities.hipolabs.com/search")
+@Tag(name="University info", description="JSON return format documented here: http://universities.hipolabs.com/search")
+
 // @Parameter(name="name", description="name of university", example="100")
 @Slf4j
 @RestController
-@RequestMapping("/api/university/get")
+@RequestMapping("/api/university")
 public class UniversityController {
 
     ObjectMapper mapper = new ObjectMapper();
@@ -32,13 +32,14 @@ public class UniversityController {
     @Autowired
     UniversityQueryService universityQueryService;
 
-    @Operation(summary="Get a country's ISO codes and more", description ="Country data uploaded to OpenDataSoft by the International Labour Organization")
+    @Operation(summary = "Get list of universities that match a given name", description = "Uses API documented here: http://universities.hipolabs.com/search")
     @GetMapping("/get")
     public ResponseEntity<String> getUniversityName(
         @Parameter(name="name", example="Harvard") @RequestParam String name
     ) throws JsonProcessingException {
-        // log.info("getUniversityName: name={}", getUniversityName);
         String result = universityQueryService.getJSON(name);
+        // log.info(result);
+        System.out.println(result);
         return ResponseEntity.ok().body(result);
     }
 

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
@@ -38,8 +38,6 @@ public class UniversityController {
         @Parameter(name="name", example="Harvard") @RequestParam String name
     ) throws JsonProcessingException {
         String result = universityQueryService.getJSON(name);
-        // log.info(result);
-        System.out.println(result);
         return ResponseEntity.ok().body(result);
     }
 

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
@@ -1,9 +1,45 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import edu.ucsb.cs156.spring.backenddemo.services.CountryCodeQueryService;
+import lombok.extern.slf4j.Slf4j;
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="University info")
+// @Operation(summary = "Get info about universities based on their name", description = "JSON return format documented here: http://universities.hipolabs.com/search")
+// @Parameter(name="name", description="name of university", example="100")
+@Slf4j
 @RestController
+@RequestMapping("/api/university/get")
 public class UniversityController {
-    
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    UniversityQueryService universityQueryService;
+
+    @Operation(summary="Get a country's ISO codes and more", description ="Country data uploaded to OpenDataSoft by the International Labour Organization")
+    @GetMapping("/get")
+    public ResponseEntity<String> getUniversityName(
+        @Parameter(name="name", example="Harvard") @RequestParam String name
+    ) throws JsonProcessingException {
+        // log.info("getUniversityName: name={}", getUniversityName);
+        String result = universityQueryService.getJSON(name);
+        return ResponseEntity.ok().body(result);
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
@@ -1,0 +1,53 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(value = UniversityController.class)
+public class UniversityControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  UniversityQueryService mockUniversityQueryService;
+
+
+  @Test
+  public void test_getUniversityInfo() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String name = "Harvard";
+    when(mockUniversityQueryService.getJSON(eq(name))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/university/get?name=%s", name);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+    
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/university/get` that can be used to get information
about a particular University.

http://team01-a-k-u-m-a-r-dev.dokku-03.cs.ucsb.edu/swagger-ui/index.html

Closes #15 

